### PR TITLE
More closings related features

### DIFF
--- a/babex-vue/.eslintrc.js
+++ b/babex-vue/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
   rules: {
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
-    '@typescript-eslint/no-non-null-assertion': 'off'
+    '@typescript-eslint/no-non-null-assertion': 'off',
+    'prefer-const': 'off'
   }
 }

--- a/babex-vue/src/api.ts
+++ b/babex-vue/src/api.ts
@@ -131,6 +131,10 @@ class GenericApiPart<T> extends ApiPart {
     async create(values: T) {
         return this.client.post(this.endpoint, values);
     }
+
+    async createMany(values: T[]) {
+        return this.client.post(this.endpoint, values);
+    }
 }
 
 

--- a/babex-vue/src/components/agenda/AgendaActions.vue
+++ b/babex-vue/src/components/agenda/AgendaActions.vue
@@ -23,7 +23,8 @@
         </div>
         <div v-if="context.type=='date-range'" class="action-panel">
             <h5>Add closing</h5>
-            <ClosingForm :key="Math.random()" :start="context.start" :end="context.end" :locations="context.locations ?? []" @done="$emit('done')" />
+            <ClosingForm :key="Math.random()" :start="context.start" :end="context.end" :locations="context.locations ?? []" @done="$emit('done')"
+                         :calendar="context.calendar" />
         </div>
     </div>
 </template>

--- a/babex-vue/src/components/agenda/AgendaCalendar.vue
+++ b/babex-vue/src/components/agenda/AgendaCalendar.vue
@@ -29,7 +29,7 @@
             id: event.id,
             start: event.start,
             end: event.end,
-            title:'Closed',
+            title: 'Closed',
             extra: event.is_global ? 'Entire building' : event.location_name,
             display: 'block',
             category: 'closing',

--- a/babex-vue/src/components/agenda/AgendaHome.vue
+++ b/babex-vue/src/components/agenda/AgendaHome.vue
@@ -27,7 +27,8 @@
             type: 'date-range',
             start: selectionInfo.start,
             end: selectionInfo.end,
-            locations: props.locations
+            locations: props.locations,
+            calendar: calendar.value
         };
     }
 
@@ -41,7 +42,8 @@
         actionContext.value = {
             type: 'event-select',
             event: event,
-            locations: props.locations
+            locations: props.locations,
+            calendar: calendar.value
         };
     }
 

--- a/babex-vue/src/components/agenda/ClosingForm.vue
+++ b/babex-vue/src/components/agenda/ClosingForm.vue
@@ -1,26 +1,35 @@
 <script lang="ts" setup>
-    import {defineEmits, defineProps, ref} from 'vue';
+    import {defineEmits, defineProps, ref, onUnmounted, watchEffect} from 'vue';
     import {babexApi} from '../../api';
     import {Location} from '@/types';
     import DateTimePicker from '../DateTimePicker.vue';
+    import {EventApi} from '@fullcalendar/core';
+    import AgendaCalendar from './AgendaCalendar.vue';
 
     const props = defineProps<{
         start?: Date,
         end?: Date,
         locations: Location[],
         // eslint-disable-next-line
-        event?: any
+        event?: any,
+        calendar?: typeof AgendaCalendar,
     }>();
 
     const emit = defineEmits(['done']);
+
+    const DAY = 24 * 3600 * 1000; // day span in milliseconds
 
     const form = ref({
         start: props.event ? props.event.start : props.start,
         end: props.event ? props.event.end : props.end,
         is_global: props.event ? props.event.extendedProps.original.is_global : true,
         location: props.event ? props.event.extendedProps.original.location : null,
-        comment: props.event ? props.event.extendedProps.original.comment : null
+        comment: props.event ? props.event.extendedProps.original.comment : null,
+        repeat: false,
+        repeatDays: 1
     });
+
+    const temporaryEvents = ref<EventApi[]>([]);
 
     async function remove() {
         babexApi.agenda.closing.delete(props.event.id).then(() => {
@@ -28,23 +37,65 @@
         });
     }
 
-    function onSubmit(event: Event) {
+    function onSubmit(ev: Event) {
         let promise;
 
         if (props.event) {
             promise = babexApi.agenda.closing.update(props.event.id, form.value);
         }
         else {
-            promise = babexApi.agenda.closing.create(form.value);
+            let closings = temporaryEvents.value.map((event) => {
+                return {
+                    start: event.start!,
+                    end: event.end!,
+                    is_global: form.value.is_global,
+                    location: form.value.location,
+                    comment: form.value.comment
+                };
+            });
+            promise = babexApi.agenda.closing.createMany(closings);
         }
 
         promise.then(() => emit('done'));
 
-        event.preventDefault();
-        event.stopPropagation();
+        ev.preventDefault();
+        ev.stopPropagation();
         return false;
     }
 
+    if (!props.event) {
+        // Interactively create temporary events in the calendar, to visually assist
+        // with repeating closings. Only available when creating a new closing
+        watchEffect(() => {
+            temporaryEvents.value.forEach((event) => {
+                event.remove();
+            })
+            temporaryEvents.value = [];
+            let range = form.value.repeat ? form.value.repeatDays : 1;
+            for(let i=0; i<range; i++) {
+                let event = props.calendar?.calendar.getApi().addEvent({
+                    start: new Date(form.value.start.getTime() + (DAY * i)),
+                    end: new Date(form.value.end.getTime() + (DAY * i)),
+                    category: 'closing',
+                    display: 'block',
+                    title: 'Closed',
+                    extra: ''
+                });
+                temporaryEvents.value.push(event);
+            }
+        });
+
+        onUnmounted(() => {
+            temporaryEvents.value.forEach((event) => {
+                event.remove();
+            })
+        });
+    }
+
+    function isRepeatAllowed() {
+        // check if the selected range is less than 24 hours
+        return (form.value.end.getTime() - form.value.start.getTime()) < DAY;
+    }
 </script>
 
 <template>
@@ -64,6 +115,16 @@
         <option v-for="location in locations"
                 :key="location.id" :value="location.id">{{ location.name }}</option>
       </select>
+    </div>
+    <div v-if="!props.event && isRepeatAllowed()"> <!-- only available when creating a new closing -->
+        <div class="form-check">
+            <label>
+                <input class="form-check-input" v-model="form.repeat" type="checkbox" value="false" />
+                Repeat for
+            </label>
+            <input type="number" class="ms-2 repeat-days form-control" min="1" v-model="form.repeatDays"
+                   :disabled="!form.repeat" /> days
+        </div>
     </div>
     <div>
       <label>Comments:</label>
@@ -94,5 +155,10 @@
 
     .btn.save {
         margin-top: 6px;
+    }
+
+    .repeat-days {
+        width: 8ex;
+        display: inline;
     }
 </style>

--- a/babex-vue/src/types.ts
+++ b/babex-vue/src/types.ts
@@ -36,6 +36,7 @@ interface Call {
 }
 
 interface ActionContext {
+    calendar?: any,
     type?: string,
     event?: Dictionary,
     locations?: Location[],

--- a/lab/agenda/locale/en/LC_MESSAGES/django.po
+++ b/lab/agenda/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,48 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-12-20 10:28+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: agenda/models.py:10
+msgid "agenda:closing:attribute:start"
+msgstr "Start"
+
+#: agenda/models.py:11
+msgid "agenda:closing:attribute:end"
+msgstr "End"
+
+#: agenda/models.py:15
+msgid "agenda:closing:attribute:location"
+msgstr "Location"
+
+#: agenda/models.py:18
+msgid "agenda:cosing:attribute:is_global"
+msgstr "Entire building"
+
+#: agenda/models.py:20
+msgid "agenda:cosing:attribute:comment"
+msgstr "Comment"
+
+#: agenda/templates/agenda/closings_admin.html:8
+#: agenda/templates/agenda/closings_admin.html:14
+msgid "agenda:closings:header"
+msgstr "Closings"
+
+#: agenda/templates/agenda/closings_admin.html:75
+msgid "agenda:closings:remove"
+msgstr "Remove closings"

--- a/lab/agenda/models.py
+++ b/lab/agenda/models.py
@@ -4,7 +4,7 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
 from experiments.models import Location
-from experiments.models import Appointment
+
 
 class Closing(models.Model):
     start = models.DateTimeField(_('closing:attribute:start'), db_index=True)

--- a/lab/agenda/models.py
+++ b/lab/agenda/models.py
@@ -7,16 +7,17 @@ from experiments.models import Location
 
 
 class Closing(models.Model):
-    start = models.DateTimeField(_('closing:attribute:start'), db_index=True)
-    end = models.DateTimeField(_('closing:attribute:end'), db_index=True)
+    start = models.DateTimeField(_('agenda:closing:attribute:start'), db_index=True)
+    end = models.DateTimeField(_('agenda:closing:attribute:end'), db_index=True)
 
     # SET_NULL will let us keep closings history if for some reason a location is removed
-    location = models.ForeignKey(Location, on_delete=models.SET_NULL, null=True)
+    location = models.ForeignKey(Location, on_delete=models.SET_NULL, null=True,
+                                 verbose_name=_('agenda:closing:attribute:location'))
 
     # used to indicate entire lab is closed
-    is_global = models.BooleanField()
+    is_global = models.BooleanField(_('agenda:cosing:attribute:is_global'))
 
-    comment = models.TextField(null=True)
+    comment = models.TextField(_('agenda:cosing:attribute:comment'), null=True)
 
 
 class ClosingSerializer(serializers.ModelSerializer):

--- a/lab/agenda/templates/agenda/closings_admin.html
+++ b/lab/agenda/templates/agenda/closings_admin.html
@@ -21,7 +21,6 @@
 <div class="w-100 ps-5 pe-5">
     <div class="col-12">
         <p>
-            {% trans 'experiments:home:info_text' %}
         </p>
         <form method="post">
             {% csrf_token %}
@@ -73,7 +72,7 @@
                     {% endfor %}
                 </tbody>
             </table>
-            <button class="btn btn-primary">Remove closings</button>
+            <button class="btn btn-primary">{% trans 'agenda:closings:remove' %}</button>
         </form>
         <br/>
     </div>

--- a/lab/agenda/templates/agenda/closings_admin.html
+++ b/lab/agenda/templates/agenda/closings_admin.html
@@ -1,0 +1,81 @@
+{% extends "base/babex_base.html" %}
+{% load i18n %}
+{% load transformat %}
+{% load datatables %}
+{% load get_field_name %}
+
+{% block header_title %}
+    {% trans 'agenda:closings:header' %} - {{ block.super }}
+{% endblock %}
+
+{% block pre-messages-content %}
+    <div class="uu-hero justify-content-between align-items-center">
+        <h1 class="h2">
+            {% trans 'agenda:closings:header' %}
+        </h1>
+
+    </div>
+{% endblock %}
+
+{% block content %}
+<div class="w-100 ps-5 pe-5">
+    <div class="col-12">
+        <p>
+            {% trans 'experiments:home:info_text' %}
+        </p>
+        <form method="post">
+            {% csrf_token %}
+            <table class="dt" width="100%" data-language="{% datatables_lang %}">
+                <thead>
+                    <tr>
+                        <th>
+                        </th>
+                        <th>
+                            {% get_verbose_field_name "agenda" "Closing" "start" %}
+                        </th>
+                        <th>
+                            {% get_verbose_field_name "agenda" "Closing" "end" %}
+                        </th>
+                        <th>
+                            {% get_verbose_field_name "agenda" "Closing" "is_global" %}
+                        </th>
+                        <th>
+                            {% get_verbose_field_name "agenda" "Closing" "location" %}
+                        </th>
+                        <th>
+                            {% get_verbose_field_name "agenda" "Closing" "comment" %}
+                        </th>
+                    </tr>
+                </thead>
+
+                <tbody>
+                    {% for closing in object_list %}
+                        <tr>
+                            <td>
+                                <input class="checkbox" type="checkbox" name="closings" value="{{ closing.pk }}">
+                            </td>
+                            <td>
+                                {{ closing.start }}
+                            </td>
+                            <td>
+                                {{ closing.end }}
+                            </td>
+                            <td>
+                                <i class="icon-yesno">{{ closing.is_global|yesno:"," }}</i>
+                            </td>
+                            <td>
+                                {{ closing.location|default_if_none:'' }}
+                            </td>
+                            <td>
+                                {{ closing.comment|default_if_none:'' }}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            <button class="btn btn-primary">Remove closings</button>
+        </form>
+        <br/>
+    </div>
+</div>
+{% endblock %}

--- a/lab/agenda/urls.py
+++ b/lab/agenda/urls.py
@@ -3,13 +3,14 @@ from django.urls import path
 from rest_framework.routers import DefaultRouter
 
 from .views import agenda_home
-from .views import AppointmentFeed, ClosingViewSet, AppointmentViewSet
+from .views import AppointmentFeed, ClosingViewSet, AppointmentViewSet, ClosingsAdminView
 
 app_name = 'agenda'
 
 urlpatterns = [
     path('', agenda_home, name='home'),
     path('feed', AppointmentFeed.as_view(), name='feed'),
+    path('admin/closings', ClosingsAdminView.as_view(), name='admin.closings'),
 ]
 
 router = DefaultRouter()

--- a/lab/agenda/views.py
+++ b/lab/agenda/views.py
@@ -1,11 +1,11 @@
-from datetime import timedelta, datetime
+import braces.views as braces
 import dateutil.parser
 
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import redirect, render
-from django.http.response import JsonResponse
+from django.shortcuts import render
+from django.views import generic
 
-from rest_framework import generics, views, serializers, viewsets
+from rest_framework import generics, viewsets, status
 from rest_framework.response import Response
 
 from experiments.models import Appointment, Location
@@ -48,6 +48,14 @@ class ClosingViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(end__gte=from_date, start__lt=to_date)
 
         return queryset
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data, many=isinstance(request.data, list))
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
 
 class AppointmentViewSet(viewsets.ModelViewSet):
     serializer_class = AppointmentSerializer

--- a/lab/agenda/views.py
+++ b/lab/agenda/views.py
@@ -64,3 +64,21 @@ class AppointmentViewSet(viewsets.ModelViewSet):
         queryset = Appointment.objects.all()
         return queryset
 
+
+class ClosingsAdminView(braces.LoginRequiredMixin, generic.TemplateView):
+    # TODO: admin permissions
+    template_name = 'agenda/closings_admin.html'
+
+    def get_context_data(self, **kwargs):
+        context = dict()
+        context['object_list'] = self.get_object_list()
+        return context
+
+    def get_object_list(self):
+        return Closing.objects.all().order_by('-start')
+
+    def post(self, request, *args, **kwargs):
+        '''simple post endpoint for removing closings'''
+        pks = map(int, request.POST.getlist('closings'))
+        Closing.objects.filter(pk__in=pks).delete()
+        return self.get(request, *args, **kwargs)

--- a/lab/agenda/views.py
+++ b/lab/agenda/views.py
@@ -65,8 +65,7 @@ class AppointmentViewSet(viewsets.ModelViewSet):
         return queryset
 
 
-class ClosingsAdminView(braces.LoginRequiredMixin, generic.TemplateView):
-    # TODO: admin permissions
+class ClosingsAdminView(braces.StaffuserRequiredMixin, generic.TemplateView):
     template_name = 'agenda/closings_admin.html'
 
     def get_context_data(self, **kwargs):

--- a/lab/main/locale/en/LC_MESSAGES/django.po
+++ b/lab/main/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-05 11:52+0200\n"
+"POT-Creation-Date: 2022-12-20 10:28+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,55 +26,63 @@ msgstr ""
 "being set. Please make a different user main admin before disabling this "
 "user's main admin status."
 
-#: main/menus.py:6
+#: main/menus.py:26
 msgid "mainmenu:home"
 msgstr "Home"
 
-#: main/menus.py:11
+#: main/menus.py:32
 msgid "mainmenu:agenda"
 msgstr "Agenda"
 
-#: main/menus.py:17
+#: main/menus.py:38
 msgid "mainmenu:experiments:overview"
 msgstr "Overview"
 
-#: main/menus.py:19
+#: main/menus.py:40
 msgid "mainmenu:locations"
 msgstr "Locations"
 
-#: main/menus.py:21
+#: main/menus.py:42
 msgid "mainmenu:criteria"
 msgstr "Criteria"
 
-#: main/menus.py:25
+#: main/menus.py:46
 msgid "mainmenu:experiments"
 msgstr "Experiments"
 
-#: main/menus.py:33
+#: main/menus.py:54
 msgid "mainmenu:leaders"
 msgstr "Leaders"
 
-#: main/menus.py:36
+#: main/menus.py:57
 msgid "mainmenu:admins"
 msgstr "Admins"
 
-#: main/menus.py:41
+#: main/menus.py:62
 msgid "mainmenu:users"
 msgstr "Users"
 
-#: main/menus.py:47
+#: main/menus.py:70 main/menus.py:84
 msgid "mainmenu:participants"
 msgstr "Participants"
 
-#: main/menus.py:59
+#: main/menus.py:95
+msgid "mainmenu:admin"
+msgstr "Admin"
+
+msgid "mainmenu:admin:closings"
+msgstr "Closings"
+
+#: main/menus.py:102
 msgid "mainmenu:datamanagement"
 msgstr "Data management"
 
-#: main/menus.py:65
+#: main/menus.py:108
 msgid "footermenu:login"
 msgstr "Log in"
 
-#: main/menus.py:70 main/templates/base/login_header.html:7
+#: main/menus.py:113 main/templates/base/babex_base.html:52
+#: main/templates/base/login_header.html:7
 msgid "main:globals:logout"
 msgstr "Log out"
 
@@ -86,41 +94,38 @@ msgstr "Main admin"
 msgid "user:is_ldap_account"
 msgstr "Solis Account"
 
+#: main/templates/base/babex_base.html:18
+#: main/templates/base/babex_base.html:19
+msgid "cdh.core:uu"
+msgstr ""
+
+#. Translators: This is the title that will end up in the header (in blue)
+#: main/templates/base/babex_base.html:26
+#: main/templates/base/site_header.html:4
+msgid "site:header:title"
+msgstr "Babex Admin"
+
+#: main/templates/base/babex_base.html:50
 #: main/templates/base/login_header.html:6
 msgid "site:header:login"
 msgstr "Welcome {}!"
 
-#. Translators: This is the title that will end up in the header (in blue)
-#: main/templates/base/site_header.html:4
-msgid "site:header:title"
-msgstr "Babex Admin"
+#: main/templates/base/babex_base.html:63
+msgid "lang:en"
+msgstr ""
+
+#: main/templates/base/babex_base.html:68
+msgid "lang:nl"
+msgstr ""
 
 #. Translators: This is the title that will end up in the tab of the browser
 #: main/templates/base/site_title.html:5
 msgid "site:name"
 msgstr "Babex Admin"
 
-#: main/templates/main/index.html:6 main/templates/main/index.html:13
+#: main/templates/main/index.html:6 main/templates/main/index.html:12
 msgid "main:home:header"
 msgstr "Home"
-
-#: main/templates/main/index.html:15
-msgid "main:home:text"
-msgstr ""
-"Welcome {},<br/><br/>There are currently {} open experiments, with {} free "
-"slots. "
-
-#: main/templates/main/index.html:20
-msgid "main:home:experiments:name"
-msgstr "Experiments"
-
-#: main/templates/main/index.html:23
-msgid "main:globals:actions"
-msgstr "Actions"
-
-#: main/templates/main/index.html:43
-msgid "main:home:menu"
-msgstr "Menu"
 
 #: main/templates/main/login_lockout.html:9
 #: main/templates/main/login_lockout.html:17
@@ -239,7 +244,7 @@ msgstr "Change account '{}'"
 msgid "users:update:info_text"
 msgstr " "
 
-#: main/views/base.py:24 main/views/base.py:59
+#: main/views/base.py:26 main/views/base.py:61
 #, python-format
 msgid "Empty list and '%(class_name)s.allow_empty' is False."
 msgstr ""
@@ -255,6 +260,20 @@ msgstr "New account created!"
 #: main/views/users.py:84
 msgid "users:message:changed_password"
 msgstr "Password changed!"
+
+#~ msgid "main:home:text"
+#~ msgstr ""
+#~ "Welcome {},<br/><br/>There are currently {} open experiments, with {} "
+#~ "free slots. "
+
+#~ msgid "main:home:experiments:name"
+#~ msgstr "Experiments"
+
+#~ msgid "main:globals:actions"
+#~ msgstr "Actions"
+
+#~ msgid "main:home:menu"
+#~ msgstr "Menu"
 
 #~ msgid "mainmenu:comments"
 #~ msgstr "Comments"

--- a/lab/main/menus.py
+++ b/lab/main/menus.py
@@ -89,7 +89,7 @@ Menu.add_item(
 
 
 admin_menu = [
-    MenuItem('mainmenu:admin:closings', reverse('agenda:admin.closings'))
+    MenuItem(_('mainmenu:admin:closings'), reverse('agenda:admin.closings'))
 ]
 
 Menu.add_item('main', MenuItem(_('mainmenu:admin'),

--- a/lab/main/menus.py
+++ b/lab/main/menus.py
@@ -5,22 +5,29 @@ from django.core.handlers.wsgi import WSGIRequest
 from menu import Menu, MenuItem
 
 
-def _user_is_authenticated(x:WSGIRequest) -> bool:
+def _user_is_authenticated(x: WSGIRequest) -> bool:
     '''
     Checks whether the user x is is_authenticated
     '''
     return x.user.is_authenticated
 
-def _user_is_not_authenticated(x:WSGIRequest) -> bool:
+
+def _user_is_not_authenticated(x: WSGIRequest) -> bool:
     '''
-    Checks whether the user x is not authenticated 
+    Checks whether the user x is not authenticated
     '''
-    return not _user_is_authenticated(x) 
+    return not _user_is_authenticated(x)
+
+
+def _user_is_admin(req: WSGIRequest) -> bool:
+    return req.user.is_authenticated and req.user.is_staff
+
 
 Menu.add_item("home", MenuItem(_('mainmenu:home'),
                                reverse('main:home'),
                                exact_url=True
                                ))
+
 
 Menu.add_item("main", MenuItem(_('mainmenu:agenda'),
                                reverse('agenda:home'),
@@ -78,12 +85,17 @@ Menu.add_item(
         children=participants_menu,
         check=_user_is_authenticated,
         url=None
-        ))
+    ))
 
-# Menu.add_item("main", MenuItem(_('mainmenu:comments'),
-#                                reverse('comments:home'),
-#                                check=lambda x: x.user.is_authenticated
-#                                ))
+
+admin_menu = [
+    MenuItem('mainmenu:admin:closings', reverse('agenda:admin.closings'))
+]
+
+Menu.add_item('main', MenuItem(_('mainmenu:admin'),
+                               children=admin_menu,
+                               check=_user_is_admin,
+                               url=None))
 
 
 if 'datamanagement' in settings.INSTALLED_APPS:


### PR DESCRIPTION
- Added support for repeated closings of a given time span. For example, when the building is closed at 17:00 for two weeks, you can create a closing from 17:00 to 00:00 and choose to repeat for 14 days.
This is treated as separate closings by the backend, but saves some repetitive work for the lab manager.
- Added a simple closings admin view that lists all closings, and allows mass removal.
