### PR TITLE
Nicer file-picker styling

### DIFF
--- a/babex-vue/src/components/FilePicker.vue
+++ b/babex-vue/src/components/FilePicker.vue
@@ -37,8 +37,8 @@
 
 <template>
     <div v-for="file in existing" :key="file.pk">
-        <div class="existing-file">
-            <div class="label" :class="{removed: toRemove.has(file.pk)}">
+        <div class="existing-file input-group">
+            <div class="input-group-text flex-grow-1 justify-content-between" :class="{'text-decoration-line-through': toRemove.has(file.pk)}">
                 <div><a :href="file.link"><span class="icon-file-text2">&#xe926;</span>{{ file.name }}</a></div>
                 <div>{{ formatDateTime(new Date(file.created)) }}</div>
             </div>
@@ -63,34 +63,11 @@
 </template>
 
 <style scoped>
-    .existing-file {
-        display: flex;
-        margin-bottom: 5px;
-    }
-
-    .existing-file .label {
-        display: flex;
-        justify-content: space-between;
-        padding: 5px;
-        width: 100%;
-        border: 1px solid #dedede;
-        background: #dedede;
-    }
-
     .existing-file a {
         text-decoration: none;
     }
 
     .existing-file a span {
-        padding-right: 5px;
-    }
-
-    .field button, .existing-file button {
-        margin-left: 5px;
-        width: 20%;
-    }
-
-    .removed {
-        text-decoration: line-through;
+        padding-right: .3125rem;
     }
 </style>

--- a/babex-vue/src/components/FilePicker.vue
+++ b/babex-vue/src/components/FilePicker.vue
@@ -46,10 +46,10 @@
             <button v-if="!toRemove.has(file.pk)" type="button" class="btn btn-danger" @click="removeExisting(file.pk)">{{ _('Remove') }}</button>
         </div>
     </div>
-    <div v-for="i in fields" :key="i">
-        <div class="field">
+    <div v-for="i in fields" :key="i" class="mb-2">
+        <div class="input-group">
             <input type="file" :name="name" class="form-control">
-            <button type="button" class="btn btn-secondary" @click="remove(i)">{{ _('Remove') }}</button>
+            <button type="button" class="btn btn-danger" @click="remove(i)">{{ _('Remove') }}</button>
         </div>
     </div>
 
@@ -88,15 +88,6 @@
     .field button, .existing-file button {
         margin-left: 5px;
         width: 20%;
-    }
-
-    .field {
-        display: flex;
-        margin-bottom: 5px;
-    }
-
-    input {
-        margin-bottom: 5px;
     }
 
     .removed {


### PR DESCRIPTION
This PR is meant to apply over existing PR #182

Yes, this is me being pedantic with formatting/layouting. But hey, that's why I created #159 for myself ;)

It changes the following:

Existing file:
- Replaced custom CSS with existing CSS classes where applicable
- Used an input-group to standardize its visuals with the input version
- Replaced px based value with equivalent rem value. Why? Because mixing the two cause interesting scaling issues. It's better to always use rem, as uu-bootstrap (well, bootstrap) uses that. 

New input:
- Changes how margin is applied by applying it to the container-div. This solves the remove button from being so un-aligned
- The button now has a nice danger-color, for consistency
- The button is now part of an input-group, visually connecting them

Example:
![image](https://github.com/UiL-OTS-labs/babex/assets/7061963/22530ecc-8deb-48db-8879-8c598104fccf)
